### PR TITLE
Add connect-flash to the dependency list

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "passport": "*",
     "passport-local": "*",
     "passport-facebook": "*",
-    "mongoose": "~3.6.4"
+    "mongoose": "~3.6.4",
+    "connect-flash": "*"
   }
 }


### PR DESCRIPTION
On my MAC running the latest version of Mac OS and on Ubuntu 12.04, 'npm start' fails in app.js when calling require('connect-flash');
